### PR TITLE
Add community HPC RSE

### DIFF
--- a/communities.csv
+++ b/communities.csv
@@ -24,3 +24,4 @@ OLS,A not-for-profit organisation dedicated to capacity building and diversifyin
 UNIVERSE-HPC,Understanding and Nurturing an Integrated Vision for Education in RSE and HPC ,http://www.universe-hpc.ac.uk/,national,training
 The Turing Way,"Our goal is to provide all the information that researchers and data scientists in academia, industry and the public sector need to ensure that the projects they work on are easy to reproduce and reuse.",https://book.the-turing-way.org/,international,community
 Wellcome,"Wellcome supports discovery research into life, health and wellbeing.",https://wellcome.org/,international,life-sciences
+HPC RSE community, The group aims to address the lack of an obvious community initiative leading to problems for many new RSEs who enter the world of HPC, https://www.archer2.ac.uk/news/2024/03/28/hpc-rse-meetup.html, national, community


### PR DESCRIPTION
I propose to add a new community, perhaps, more precisely to say, a group which makes efforts to build the HPC RSE community. The relevant links for it are:

- [hpc-rse-meetup](https://www.archer2.ac.uk/news/2024/03/28/hpc-rse-meetup.html)
- [hpc-days-2024-abstracts](https://scicomp.webspace.durham.ac.uk/events/code_performance_series/durham-hpc-days-2024/hpc-days-2024-abstracts/#wed-04) (search for title: "Building the HPC RSE Community")

They mentioned at HPC RSE meetup (March 2024) and at Durham HPC Days (May 2024) how the "lack of an obvious community initiative leads to problems for the many new RSEs entering the world of HPC".

The sentence just came in to my mind from our CommuneRS website: "Community building is hard" which exactly describes the struggles of HPC RSE community.